### PR TITLE
Fix: Corrige a implementação da proteção CSRF

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -22,26 +22,29 @@ from routers import proprietarios, imoveis, participacoes, reportes, extras, tra
 from routers.auth import verify_token
 from utils.error_handlers import global_exception_handler
 
-# Configuração CSRF - TEMPORARIAMENTE DESABILITADA
-# @CsrfProtect.load_config
-# def get_csrf_config():
-#     from dotenv import load_dotenv
-#     import os
-#     load_dotenv()
-#     csrf_secret = os.getenv("CSRF_SECRET_KEY")
-#     if not csrf_secret:
-#         raise RuntimeError("CSRF_SECRET_KEY must be set in the environment")
-#     return [
-#         ('secret_key', csrf_secret),
-#         ('cookie_samesite', 'lax'),
-#         ('token_location', 'header'),
-#         ('token_key', 'X-CSRF-Token')
-#     ]
+# Configuração CSRF
+@CsrfProtect.load_config
+def get_csrf_config():
+    from dotenv import load_dotenv
+    import os
+    load_dotenv()
+    csrf_secret = os.getenv("CSRF_SECRET_KEY")
+    if not csrf_secret:
+        raise RuntimeError("CSRF_SECRET_KEY must be set in the environment")
+    return [
+        ('secret_key', csrf_secret),
+        ('cookie_samesite', 'lax'),
+        ('token_location', 'header'),
+        ('token_key', 'X-CSRF-Token')
+    ]
 
 # Configuração da aplicação
 
 app = FastAPI(**APP_CONFIG)
 app.add_middleware(CORSMiddleware, **CORS_CONFIG)
+# Adiciona o middleware CSRF, que é ativado pela configuração acima
+app.add_middleware(CsrfProtect)
+
 
 # Configuração de Rate Limiting para prevenir ataques de força bruta
 from slowapi import Limiter, _rate_limit_exceeded_handler
@@ -147,22 +150,8 @@ def get_csrf_token(csrf_protect: CsrfProtect = Depends()):
     csrf_protect.set_csrf_cookie(response)
     return response
 
-# Middleware para verificar CSRF em rutas POST/PUT/DELETE
-@app.middleware("http")
-async def csrf_middleware(request, call_next):
-    if request.method in ["POST", "PUT", "DELETE", "PATCH"]:
-        # Skip CSRF for auth endpoints and health check
-        if not request.url.path.startswith("/api/auth/") and request.url.path != "/api/health":
-            # Verificar CSRF token
-            csrf_token = request.headers.get("X-CSRF-Token")
-            if not csrf_token:
-                return JSONResponse(
-                    status_code=403,
-                    content={"detail": "CSRF token missing"}
-                )
-            # Aqui se podria verificar el token, pero fastapi-csrf-protect lo maneja
-    response = await call_next(request)
-    return response
+# O middleware fastapi-csrf-protect agora lida com a verificação de CSRF.
+# O middleware manual foi removido.
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
A proteção CSRF estava desativada e substituída por um middleware manual e inseguro que apenas verificava a existência do cabeçalho do token, sem validá-lo.

Esta correção remove o middleware manual e reativa a configuração da biblioteca `fastapi-csrf-protect`, que já era uma dependência do projeto.

As seguintes alterações foram feitas:
- Adicionado um arquivo `backend/.env` com as chaves de ambiente necessárias, incluindo `CSRF_SECRET_KEY`.
- Em `backend/main.py`, a configuração `@CsrfProtect.load_config` foi descomentada.
- O middleware `CsrfProtect` foi adicionado à aplicação FastAPI.
- O middleware manual e inseguro foi removido.

O frontend já estava preparado para lidar com a proteção CSRF, não necessitando de alterações.