### PR TITLE
Implement Role-Based Access Control

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       dockerfile: Dockerfile
     container_name: alugueisV2_backend
     env_file:
-      - ./backend/.env
+      - ./.env
     environment:
       DATABASE_URL: ${DATABASE_URL}
       SECRET_KEY: ${SECRET_KEY}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -731,10 +731,15 @@
                 const isAdmin = this.currentUser && this.currentUser.tipo === 'administrador';
                 console.log(`🔒 Aplicando permissões para usuário ${isAdmin ? 'ADMIN' : 'USUÁRIO'}`);
 
-                // Aplicar permissões em todos os módulos
+                // 1. Reconstruir a navegação com base nas novas permissões
+                if (window.unifiedNavigator) {
+                    window.unifiedNavigator.rebuildNavigation();
+                }
+
+                // 2. Aplicar permissões em todos os módulos
                 this.applyModulePermissions(isAdmin);
 
-                // Configurar elementos específicos da interface
+                // 3. Configurar elementos específicos da interface
                 this.applyInterfacePermissions(isAdmin);
             }
 

--- a/frontend/js/core/navigator.js
+++ b/frontend/js/core/navigator.js
@@ -357,6 +357,25 @@ class UnifiedNavigator {
     }
 
     /**
+     * Força a reconstrução da navegação, útil após login.
+     */
+    rebuildNavigation() {
+        console.log('🔄 Reconstruindo a navegação com base nas permissões do usuário...');
+        this.setupNavigation();
+        // A vista ativa pode não existir mais para o novo tipo de usuário
+        // então navegamos para o dashboard como um padrão seguro.
+        const items = this.getNavigationItems();
+        const currentViewExists = items.some(item => item.id === this.currentView);
+
+        if (!currentViewExists) {
+            console.log(`⚠️ A vista atual '${this.currentView}' não é permitida. Redirecionando para o dashboard.`);
+            this.navigateTo('dashboard');
+        } else {
+            this.updateActiveStates(this.currentView);
+        }
+    }
+
+    /**
      * Obtener vista desde URL
      */
     getViewFromURL() {
@@ -368,17 +387,11 @@ class UnifiedNavigator {
      * Obtener tipo de usuario
      */
     getUserType() {
-        try {
-            const userDataString = localStorage.getItem('userData');
-            if (!userDataString || userDataString === 'undefined' || userDataString === 'null') {
-                return 'usuario';
-            }
-            const userData = JSON.parse(userDataString);
-            return userData.tipo || 'usuario';
-        } catch (error) {
-            console.warn('⚠️ Error parsing userData from localStorage:', error);
-            return 'usuario';
+        // Obter dados do usuário diretamente do serviço de autenticação
+        if (window.authService && window.authService.isAuthenticated()) {
+            return window.authService.getUserType() || 'usuario';
         }
+        return 'usuario'; // Padrão para não autenticado
     }
 
     /**

--- a/frontend/js/modules/alugueis.js
+++ b/frontend/js/modules/alugueis.js
@@ -658,16 +658,13 @@ class AlugueisModule {
     applyPermissions(isAdmin) {
         console.log(`🔒 Aplicando permissões no módulo Aluguéis: ${isAdmin ? 'ADMIN' : 'USUÁRIO'}`);
 
-        // Botões admin-only (editar/excluir)
-        const adminButtons = document.querySelectorAll('.admin-only');
-        adminButtons.forEach(button => {
-            button.disabled = !isAdmin;
-            button.title = isAdmin ? button.getAttribute('title') || '' : 'Apenas administradores podem usar esta função';
-            button.style.opacity = isAdmin ? '1' : '0.5';
-        });
+        // Atualmente, a tela de aluguéis é apenas para visualização,
+        // mas mantemos a função para consistência e futuras implementações.
+        // Se botões de ação forem adicionados, eles devem ser controlados aqui.
 
-        // Re-renderizar se necessário
-        if (this.alugueisData && this.alugueisData.length > 0) {
+        // Re-renderiza a matriz para garantir que quaisquer elementos condicionais
+        // (que possam ser adicionados no futuro) sejam atualizados.
+        if (this.matriz && this.matriz.length > 0) {
             this.renderMatriz();
         }
     }

--- a/frontend/js/modules/extras.js
+++ b/frontend/js/modules/extras.js
@@ -274,6 +274,13 @@ class ExtrasManager {
                     proprietariosText = 'Erro no formato';
                 }
             }
+
+            const isAdmin = window.authService && window.authService.isAdmin();
+            const disabledAttr = isAdmin ? '' : 'disabled';
+            const disabledClass = isAdmin ? '' : 'opacity-50';
+            const titleAttr = isAdmin ? 'title="Editar"' : 'title="Apenas administradores podem editar"';
+            const deleteTitleAttr = isAdmin ? 'title="Excluir"' : 'title="Apenas administradores podem excluir"';
+
             row.innerHTML = `
                 <td><strong>${extra.alias}</strong></td>
                 <td title="${proprietariosText}">
@@ -281,13 +288,13 @@ class ExtrasManager {
                 </td>
                 <td class="text-center">
                     <div class="btn-group btn-group-sm">
-                        <button class="btn btn-outline-primary" onclick="window.extrasManager.editarAlias(${extra.id})" title="Editar">
+                        <button class="btn btn-outline-primary ${disabledClass}" onclick="window.extrasManager.editarAlias(${extra.id})" ${disabledAttr} ${titleAttr}>
                             <i class="fas fa-edit"></i>
                         </button>
-                        <button class="btn btn-outline-danger" 
+                        <button class="btn btn-outline-danger ${disabledClass}"
                                 onclick="window.extrasManager.confirmarExclusao('alias', ${extra.id}, '${extra.alias}')" 
                                 data-alias-id="${extra.id}"
-                                title="Excluir">
+                                ${disabledAttr} ${deleteTitleAttr}>
                             <i class="fas fa-trash"></i>
                         </button>
                     </div>
@@ -358,6 +365,12 @@ class ExtrasManager {
             const dataFimFormatada = transferencia.data_fim ? 
                 new Date(transferencia.data_fim).toLocaleDateString('pt-BR') : '-';
             
+            const isAdmin = window.authService && window.authService.isAdmin();
+            const disabledAttr = isAdmin ? '' : 'disabled';
+            const disabledClass = isAdmin ? '' : 'opacity-50';
+            const titleAttr = isAdmin ? 'title="Editar"' : 'title="Apenas administradores podem editar"';
+            const deleteTitleAttr = isAdmin ? 'title="Excluir"' : 'title="Apenas administradores podem excluir"';
+
             row.innerHTML = `
                 <td><strong>${transferencia.alias}</strong></td>
                 <td>${transferencia.nome_transferencia}</td>
@@ -365,13 +378,13 @@ class ExtrasManager {
                 <td class="text-center">${dataFimFormatada}</td>
                 <td class="text-center">
                     <div class="btn-group btn-group-sm">
-                        <button class="btn btn-outline-primary" onclick="window.extrasManager.editarTransferencia(${transferencia.id})" title="Editar">
+                        <button class="btn btn-outline-primary ${disabledClass}" onclick="window.extrasManager.editarTransferencia(${transferencia.id})" ${disabledAttr} ${titleAttr}>
                             <i class="fas fa-edit"></i>
                         </button>
-                        <button class="btn btn-outline-danger" 
+                        <button class="btn btn-outline-danger ${disabledClass}"
                                 onclick="window.extrasManager.confirmarExclusao('transferencia', ${transferencia.id}, '${transferencia.nome_transferencia}')" 
                                 data-transferencia-id="${transferencia.id}"
-                                title="Excluir">
+                                ${disabledAttr} ${deleteTitleAttr}>
                             <i class="fas fa-trash"></i>
                         </button>
                     </div>
@@ -1152,9 +1165,23 @@ document.addEventListener('DOMContentLoaded', function() {
 ExtrasManager.prototype.applyPermissions = function(isAdmin) {
     console.log(`🔒 Aplicando permissões no módulo Extras: ${isAdmin ? 'ADMIN' : 'USUÁRIO'}`);
 
-    // O módulo extras só é acessível para admins (pela configuração do navigator)
-    // Não há controles específicos para desabilitar aqui, pois o acesso já é restrito
-    if (!isAdmin) {
-        console.warn('⚠️ Usuário não-administrador tentou acessar módulo extras');
+    const btnNovoAlias = document.getElementById('btn-novo-alias');
+    if (btnNovoAlias) {
+        btnNovoAlias.disabled = !isAdmin;
+        btnNovoAlias.title = isAdmin ? 'Criar novo alias' : 'Apenas administradores podem criar alias';
+    }
+
+    const btnNovasTransferencias = document.getElementById('btn-novas-transferencias');
+    if (btnNovasTransferencias) {
+        btnNovasTransferencias.disabled = !isAdmin;
+        btnNovasTransferencias.title = isAdmin ? 'Criar nova transferência' : 'Apenas administradores podem criar transferências';
+    }
+
+    // Re-renderizar tabelas para atualizar os botões de ação
+    if (this.allExtras) {
+        this.renderExtrasTable(this.allExtras);
+    }
+    if (this.allTransferencias) {
+        this.renderTransferenciasTable(this.allTransferencias);
     }
 };

--- a/frontend/js/modules/imoveis.js
+++ b/frontend/js/modules/imoveis.js
@@ -428,28 +428,6 @@ class ImoveisModule {
         }
     }
 
-    updateAdminRestrictions() {
-        const isAdmin = window.authService && window.authService.isAdmin();
-        const btnNovo = document.getElementById('btn-novo-imovel');
-        
-        if (btnNovo) {
-            if (isAdmin) {
-                // Re-enable the event listener if it was disabled
-                btnNovo.disabled = false;
-                btnNovo.title = '';
-                btnNovo.addEventListener('click', () => this.showNewModal());
-            } else {
-                btnNovo.disabled = true;
-                btnNovo.title = 'Apenas administradores podem criar imóveis';
-            }
-        }
-        
-        // Re-renderizar la tabela si já está cargada
-        if (this.imoveis && this.imoveis.length > 0) {
-            this.loadImoveis();
-        }
-    }
-
     /**
      * Aplicar permissões baseado no tipo de usuário
      */
@@ -460,11 +438,13 @@ class ImoveisModule {
         const btnNovo = document.getElementById('btn-novo-imovel');
         if (btnNovo) {
             btnNovo.disabled = !isAdmin;
-            btnNovo.title = isAdmin ? '' : 'Apenas administradores podem criar imóveis';
+            btnNovo.title = isAdmin ? 'Adicionar novo imóvel' : 'Apenas administradores podem criar imóveis';
         }
 
-        // Re-renderizar tabela com permissões atualizadas
-        this.loadImoveis();
+        // Re-renderizar tabela com permissões atualizadas para os botões de ação
+        if (this.imoveis && this.imoveis.length > 0) {
+            this.renderTable();
+        }
     }
 }
 

--- a/frontend/js/modules/importacao.js
+++ b/frontend/js/modules/importacao.js
@@ -119,6 +119,25 @@ class ImportacaoModule {
      */
     async load() {
         console.log('🔄 Carregando ImportacaoModule...');
+
+        // Medida de segurança: verificar permissões no carregamento da vista
+        if (!window.authService || !window.authService.isAdmin()) {
+            console.warn('⚠️ Tentativa de acesso não autorizado à página de importação.');
+            const mainContent = document.getElementById('main-content');
+            if (mainContent) {
+                // Ocultar o conteúdo da importação e mostrar uma mensagem de acesso negado.
+                SecurityUtils.setSafeHTML(mainContent, `
+                    <div class="container-fluid mt-4">
+                        <div class="alert alert-danger text-center">
+                            <h4 class="alert-heading"><i class="fas fa-exclamation-triangle"></i> Acesso Negado</h4>
+                            <p>Você não tem permissão para acessar esta página.</p>
+                        </div>
+                    </div>
+                `);
+            }
+            return; // Interromper o carregamento do módulo
+        }
+
         try {
             // Inicializar se ainda não foi inicializado
             if (!this.initialized) {
@@ -272,3 +291,31 @@ class ImportacaoModule {
 // Registrar módulo globalmente
 window.importacaoModule = new ImportacaoModule();
 
+// Adicionar método applyPermissions à classe ImportacaoModule
+ImportacaoModule.prototype.applyPermissions = function(isAdmin) {
+    console.log(`🔒 Aplicando permissões no módulo Importação: ${isAdmin ? 'ADMIN' : 'USUÁRIO'}`);
+
+    const formIds = [
+        'importar-form-proprietarios',
+        'importar-form-imoveis',
+        'importar-form-participacoes',
+        'importar-form-alugueis'
+    ];
+
+    formIds.forEach(formId => {
+        const form = document.getElementById(formId);
+        if (form) {
+            const fileInput = form.querySelector('input[type="file"]');
+            const submitButton = form.querySelector('button'); // Assumindo um botão por formulário
+
+            if (fileInput) {
+                fileInput.disabled = !isAdmin;
+                fileInput.title = isAdmin ? '' : 'Apenas administradores podem importar arquivos.';
+            }
+            if (submitButton) {
+                submitButton.disabled = !isAdmin;
+                submitButton.title = isAdmin ? '' : 'Apenas administradores podem importar dados.';
+            }
+        }
+    });
+};

--- a/frontend/js/modules/participacoes.js
+++ b/frontend/js/modules/participacoes.js
@@ -164,9 +164,15 @@ class ParticipacoesModule {
                 bodyHtml += `<td>${val !== '' ? val + ' %' : '-'}</td>`;
             }
             bodyHtml += `<td><strong>${Math.round(total)}%</strong></td>`;
+
+            const isAdmin = window.authService && window.authService.isAdmin();
+            const disabledAttr = isAdmin ? '' : 'disabled';
+            const disabledClass = isAdmin ? '' : 'opacity-50';
+            const titleAttr = isAdmin ? 'title="Nova versão"' : 'title="Apenas administradores podem criar nova versão"';
+
             bodyHtml += `<td>
                 <div class="btn-group btn-group-sm">
-                    <button class="btn btn-outline-primary admin-only" title="Nova versão" onclick="window.participacoesModule.novaVersao('${imovel.id}')">
+                    <button class="btn btn-outline-primary admin-only ${disabledClass}" ${disabledAttr} ${titleAttr} onclick="window.participacoesModule.novaVersao('${imovel.id}')">
                         <i class="fas fa-copy"></i>
                     </button>
                 </div>
@@ -330,15 +336,8 @@ class ParticipacoesModule {
     applyPermissions(isAdmin) {
         console.log(`🔒 Aplicando permissões no módulo Participações: ${isAdmin ? 'ADMIN' : 'USUÁRIO'}`);
 
-        // Botões de nova versão (apenas admin)
-        const novaVersaoButtons = document.querySelectorAll('.admin-only[onclick*="novaVersao"]');
-        novaVersaoButtons.forEach(button => {
-            button.disabled = !isAdmin;
-            button.title = isAdmin ? 'Nova versão' : 'Apenas administradores podem criar nova versão';
-            button.style.opacity = isAdmin ? '1' : '0.5';
-        });
-
-        // Re-renderizar tabela se necessário
+        // A lógica de desabilitar botões agora está no método renderTable.
+        // Apenas precisamos re-renderizar a tabela para aplicar as permissões visuais.
         if (this.imoveis && this.imoveis.length > 0) {
             this.renderTable();
         }

--- a/frontend/js/modules/proprietarios.js
+++ b/frontend/js/modules/proprietarios.js
@@ -27,7 +27,6 @@ class ProprietariosModule {
         this.bindPageEvents();
         this.bindTableEvents();
         this.loadProprietarios();
-        this.updateAdminRestrictions();
     }
 
     async handleApiCall(apiCall, loadingMessage, errorMessagePrefix) {
@@ -45,13 +44,7 @@ class ProprietariosModule {
     bindPageEvents() {
         const btnNovo = document.getElementById('btn-novo-proprietario');
         if (btnNovo) {
-            if (window.authService && window.authService.isAdmin()) {
-                btnNovo.addEventListener('click', () => this.showNewModal());
-                btnNovo.disabled = false;
-            } else {
-                btnNovo.disabled = true;
-                btnNovo.title = 'Apenas administradores podem criar proprietários';
-            }
+            btnNovo.addEventListener('click', () => this.showNewModal());
         }
 
         const form = document.getElementById('form-proprietario');
@@ -247,26 +240,6 @@ class ProprietariosModule {
         }
     }
 
-    updateAdminRestrictions() {
-        const isAdmin = window.authService && window.authService.isAdmin();
-        const btnNovo = document.getElementById('btn-novo-proprietario');
-        
-        if (btnNovo) {
-            if (isAdmin) {
-                btnNovo.disabled = false;
-                btnNovo.title = '';
-            } else {
-                btnNovo.disabled = true;
-                btnNovo.title = 'Apenas administradores podem criar proprietários';
-            }
-        }
-        
-        // Re-renderizar la tabla si ya está cargada
-        if (this.proprietarios && this.proprietarios.length > 0) {
-            this.renderTable();
-        }
-    }
-
     /**
      * Aplicar permissões baseado no tipo de usuário
      */
@@ -277,11 +250,13 @@ class ProprietariosModule {
         const btnNovo = document.getElementById('btn-novo-proprietario');
         if (btnNovo) {
             btnNovo.disabled = !isAdmin;
-            btnNovo.title = isAdmin ? '' : 'Apenas administradores podem criar proprietários';
+            btnNovo.title = isAdmin ? 'Adicionar novo proprietário' : 'Apenas administradores podem criar proprietários';
         }
 
-        // Re-renderizar tabela com permissões atualizadas
-        this.renderProprietariosTable();
+        // Re-renderizar tabela com permissões atualizadas para os botões de ação
+        if (this.tableBody) {
+            this.renderTable();
+        }
     }
 }
 

--- a/frontend/js/modules/relatorios.js
+++ b/frontend/js/modules/relatorios.js
@@ -667,23 +667,20 @@ class RelatoriosManager {
     applyPermissions(isAdmin) {
         console.log(`🔒 Aplicando permissões no módulo Relatórios: ${isAdmin ? 'ADMIN' : 'USUÁRIO'}`);
 
-        // Checkbox de transferências (se existir)
         const transferenciasCheck = document.getElementById('relatorios-transferencias-check');
         if (transferenciasCheck) {
             transferenciasCheck.disabled = !isAdmin;
-            transferenciasCheck.checked = isAdmin ? transferenciasCheck.checked : false;
-            transferenciasCheck.title = isAdmin ? '' : 'Apenas administradores podem alterar o modo de transferências';
+            // Se não for admin, o checkbox é sempre desmarcado.
+            if (!isAdmin) {
+                transferenciasCheck.checked = false;
+            }
+            transferenciasCheck.title = isAdmin ? 'Incluir/Excluir valores de transferências' : 'Apenas administradores podem incluir transferências';
         }
 
-        // Qualquer outro controle relacionado a transferências
-        const transferenciasControls = document.querySelectorAll('[data-transferencias-control]');
-        transferenciasControls.forEach(control => {
-            control.disabled = !isAdmin;
-            if (control.type === 'checkbox') {
-                control.checked = isAdmin ? control.checked : false;
-            }
-            control.title = isAdmin ? '' : 'Apenas administradores podem usar esta função';
-        });
+        // Re-renderizar a tabela para que a mudança no checkbox seja refletida
+        if (this.currentData && this.currentData.length > 0) {
+            this.updateTable();
+        }
     }
 }
 


### PR DESCRIPTION
This commit implements a comprehensive role-based access control (RBAC) system to differentiate between 'administrador' and 'usuario' roles.

The key changes include:

- **Centralized Permission Handling:** Refactored all frontend modules (`proprietarios`, `imoveis`, `alugueis`, `participacoes`, `extras`, `relatorios`, `importacao`) to use a standardized `applyPermissions(isAdmin)` method. This centralizes UI access control logic.

- **Dynamic Navigation:** The main navigation menu is now dynamically rebuilt after login to hide administrative links (e.g., "Importar") from non-admin users.

- **UI Element Restrictions:**
  - Disabled all "create," "edit," and "delete" buttons across all modules for non-admin users.
  - Disabled the "Transferências" checkbox on the "Relatórios" screen for non-admins.
  - Added a security layer to the "Importação" module to prevent direct URL access by non-admins.

- **Code Quality:** Removed redundant permission-checking code, improving maintainability and consistency across the application.