### PR TITLE
Fix: Correct table formatting on the Participações screen

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -157,7 +157,7 @@
                                         <div class="card">
                                             <div class="card-body">
                                                 <div class="table-responsive" style="overflow-x: auto;">
-                                                    <table class="matriz-table"
+                                                    <table class="table table-bordered table-striped matriz-table"
                                                         id="participacoes-matrix-table"
                                                         style="font-size: 0.80rem; table-layout: auto; min-width: 900px; border-collapse: collapse;">
                                                         <thead class="table-dark" id="participacoes-matrix-head">


### PR DESCRIPTION
The table on the "Participações" screen was missing the necessary Bootstrap classes, causing it to render without proper styling.

This commit adds the `table`, `table-bordered`, and `table-striped` classes to the `participacoes-matrix-table` element in `frontend/index.html` to apply the correct Bootstrap styling.